### PR TITLE
ci(scorecards): run OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,19 @@
+name: "Scorecards supply-chain security"
+on: # yamllint disable-line rule:truthy
+    branch_protection_rule: ~
+    schedule:
+        - cron: "37 14 * * 6"
+    push:
+        branches: ["main", "master", "alpha", "beta"]
+permissions: {}
+jobs:
+    scorecards:
+        permissions:
+            security-events: "write"
+            id-token: "write"
+            actions: "read"
+            contents: "read"
+        uses: "anolilab/workflows/.github/workflows/scorecards.yml@1d2834fe34a15bd35bf49a1b1071a8b71e8d6319" # main
+        with:
+            branch: "main"
+            publish_results: true


### PR DESCRIPTION
Adds OpenSSF Scorecard, which every other maintained repository in the organisation runs and this one does not. It is the first workflow in this repository.

Scorecard grades the things a consumer cannot see from the outside — whether actions are pinned, whether dependencies are kept current, whether workflow permissions are least-privilege, whether branch protection is on — and publishes the result to `api.scorecard.dev`, where it can be linked from the README as a badge.

The file matches the other repositories: pinned to the current revision of the shared reusable workflow, triggered on the release branches plus a weekly cron and `branch_protection_rule`. Scorecard supports `push`/`schedule` on the default branch only, and the reusable workflow drops runs that come from any other branch.

Nothing here gates the build — Scorecard reports, it does not fail anything.

Once it has run once, the badge is:

```markdown
[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/anolilab/neore/badge)](https://scorecard.dev/viewer/?uri=github.com/anolilab/neore)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLftRo14oumJr2GEa8rPgf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated supply-chain security analysis through a scheduled and event-driven workflow.
  * Security analysis results are published for review.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->